### PR TITLE
CoreXY Update speed_test.cfg

### DIFF
--- a/speed_accel_script/speed_test.cfg
+++ b/speed_accel_script/speed_test.cfg
@@ -123,8 +123,9 @@ gcode:
     {% endif %}
 
     # Home the axis, store the step position, and set the limits for the test
-    G28                                                                             
-    G28 X Y                                                                          
+    G28
+    G28 X Y
+    G90
     _store_mcu_position                                                              
     G1 X{axis_mid} Y{axis_mid} Z20
 
@@ -151,7 +152,9 @@ gcode:
         {% endfor %}
 
         # Home the axis, verify the step position
-        G28 X Y
+        G28
+        G90
+        G4 P1000
         _compare_mcu_position STEPPER={stepper}
         G1 X{axis_mid} Y{axis_mid}
     {% endfor %}
@@ -216,9 +219,10 @@ gcode:
         { action_raise_error("Not enough distance on the axis for cruising. Either increase ACCEL or decrease MAX_VELOCITY.") }
     {% endif %}
 
-    # Home the axis, store the step position, and set the limits for the test
-    G28                                                                              
-    G28 X Y                                                                          
+    # Home the axis, store the step position, and set the limits for the test                                                                            
+    G28
+    G28 X Y
+    G90
     _store_mcu_position                                                              
     G1 X{axis_mid} Y{axis_mid} Z20                                                   
     
@@ -245,7 +249,9 @@ gcode:
             G1 {axis}{ axis_mid }                                                     
         {% endfor %}
         # Home the axis, verify the step position
-        G28 X Y                                                                      
+        G28
+        G90
+        G4 P1000
         _compare_mcu_position   
         G1 X{axis_mid} Y{axis_mid}
     {% endfor %}    
@@ -294,8 +300,9 @@ gcode:
     SAVE_GCODE_STATE NAME=TEST_SPEED
 
     # Home the axis, store the step position, and set the limits for the test
-    G28                                                                             
-    G28 X Y                                                                          
+    G28
+    G28 X Y
+    G90
     _store_mcu_position                                                              
     
     # Output parameters to g-code terminal
@@ -346,7 +353,9 @@ gcode:
     {% endfor %}    
 
     # Home the axis, verify the step position
-    G28 X Y                                                                      
+    G28
+    G90
+    G4 P1000
     _compare_mcu_position   
 
     # Reset the initial limits


### PR DESCRIPTION
Changed axis homing Gcode in the verify/compare MCU position process from a X Y axis only to full axis home (G28) to account for CoreXY in which Z axis motor contributes to X axis motion. 

Added G90 (redundant set absolute position) and 1000ms (G4 P1000) dwell prior to G1 positioning for test commands. 